### PR TITLE
Renamed cmdlet 'Export-AzureRmAutomationRunbookLog'

### DIFF
--- a/src/Logging/AzureAutomationTools.Logging.psm1
+++ b/src/Logging/AzureAutomationTools.Logging.psm1
@@ -1,6 +1,6 @@
 Set-StrictMode -Version latest
 
-function Export-AzureRmAutomationRunbookLog {
+function Export-AatAutomationRunbookLog {
     param (
         # Target ResourceGroupName of the AutomationAccount
         [Parameter(Mandatory = $true)]


### PR DESCRIPTION
Renamed cmdlet 'Export-AzureRmAutomationRunbookLog' to 'Export-AatAutomationRunbookLog'. This fixes #20.