### PR TITLE
Fixed error where job would fail if there were no logs present

### DIFF
--- a/src/Logging/AzureAutomationTools.Logging.psm1
+++ b/src/Logging/AzureAutomationTools.Logging.psm1
@@ -123,10 +123,8 @@ function Export-AatAutomationRunbookLog {
             
     Write-Output "Collecting jobs data... Done."
 
-    if ($Jobs.Count -eq 0) {
-        Write-Output "Could not find any jobs."
-        Write-Warning "Could not find any jobs."
-        return
+    if (-not $Jobs) {
+        throw "No jobs could be found on the automation account $ResourceGroupName/$AutomationAccountName"
     }
     else {
         Write-Output "Logging $($Jobs.Count) jobs..."


### PR DESCRIPTION
Fixed error where job would fail if there were no logs present. This fixes #23 